### PR TITLE
Add prompt => consent to get refresh token

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ if (!isset($_GET['code'])) {
             'ZohoCRM.modules.ALL', //Important: Define your data accessability scope here
             'ZohoCRM.settings.ALL',
         ],
-        'access_type' => 'offline' //Important: If you want to generate the refresh token, set this value as offline
+        'access_type' => 'offline', //Important: If you want to generate the refresh token, set this value as offline
+        'prompt' => 'consent'       //Important: Will not return a refresh token if this is not also set
     ]);
 
     $_SESSION['oauth2state'] = $provider->getState();


### PR DESCRIPTION
I had the same problem in [this issue](https://github.com/asadku34/oauth2-zoho/issues/4).  This PR added the missing parameter to make the example return a refresh token.  Since this only affects the readme file, no need for a new version, as Packagist will always show the latest readme.