### PR TITLE
Added Japan and Canada datacenter domains.

### DIFF
--- a/src/Provider/Zoho.php
+++ b/src/Provider/Zoho.php
@@ -25,6 +25,8 @@ class Zoho extends AbstractProvider
         'EU' => 'https://accounts.zoho.eu',
         'IN' => 'https://accounts.zoho.in',
         'CN' => 'https://accounts.zoho.com.cn',
+        'JP' => 'https://accounts.zoho.jp',
+        'CA' => 'https://accounts.zohocloud.ca',
     ];
 
     /**


### PR DESCRIPTION
The JP dc can be found listed here https://www.zoho.com/phonebridge/developer/v3/auth-request.html

and the CA dc is not yet on the docs but I found it after troubleshooting their API, also see https://community.make.com/t/zoho-crm-needs-canada-datacenter/25446

